### PR TITLE
feat: static modal for interrupts

### DIFF
--- a/demo/ModalPage.js
+++ b/demo/ModalPage.js
@@ -5,7 +5,7 @@ import { Button }           from 'pearson-compounds';
 
 import { Modal as ModalWithOutFooter } from '../index';
 import { Modal as ModalWithFooter }    from '../index';
-
+import { Modal as ModalWithoutClose }  from '../index';
 
 class ModalPage extends Component {
 
@@ -19,12 +19,13 @@ class ModalPage extends Component {
 
     this.firstButtonHandler  = _firstButtonHandler.bind(this);
     this.secondButtonHandler = _secondButtonHandler.bind(this);
+    this.thirdButtonHandler = _thirdButtonHandler.bind(this);
 
   }
 
   render() {
 
-    const { firstModalIsShown, secondModalIsShown } = this.state;
+    const { firstModalIsShown, secondModalIsShown, thirdModalIsShown } = this.state;
 
     // ======================Internationalization Example=======================
     // intl prop is injected by the injectIntl() at the bottom of the page...
@@ -36,6 +37,7 @@ class ModalPage extends Component {
     const text =  {
       initiatingButtonText  : intl.formatMessage(messages.initiatingButtonText),
       initiatingButtonText2 : intl.formatMessage(messages.initiatingButtonText2),
+      initiatingButtonText3 : intl.formatMessage(messages.initiatingButtonText3),
       headerTitle           : intl.formatMessage(messages.headerTitle),
       bodyText              : intl.formatMessage(messages.bodyText),
       closeButtonSRText     : intl.formatMessage(messages.closeButtonSRText),
@@ -61,6 +63,9 @@ class ModalPage extends Component {
               <p>{text.bodyText}</p>
             </ModalWithOutFooter>
 
+            <ModalWithoutClose id="modalWithOutClose" isShown={thirdModalIsShown} text={text} footerVisible={false} hideCloseButton={true} cancelBtnHandler={() => this.setState({thirdModalIsShown:false})} successBtnHandler={() => this.setState({thirdModalIsShown:false})} >
+              <p>{text.bodyText}</p>
+            </ModalWithoutClose>
             <Button
               btnType="primary"
               btnSize="xlarge"
@@ -80,6 +85,16 @@ class ModalPage extends Component {
               {text.initiatingButtonText2}
             </Button>
 
+            <br />
+            <br />
+
+            <Button
+              btnType="cta"
+              btnSize="xlarge"
+              onClick={this.thirdButtonHandler}
+              >
+              {text.initiatingButtonText3}
+            </Button>
           </div>
 
           <div className="code">
@@ -91,6 +106,8 @@ class ModalPage extends Component {
               <li>disableSuccessBtn:Boolean === true/false (disables the success button when footer is shown)</li>
               <li>successBtnHandler:Function === () => console.log("success")</li>
               <li>cancelBtnHandler:Function === () => console.log("cancel") function to handle closing modal should set of modalIsOpen to false</li>
+              <li>shouldCloseOnOverlayClick:Boolean === true/false, defaults to True (allow clicking on overlay to close modal)</li>
+              <li>hideCloseButton:Boolean === true/false, defaults to False (hide close button)</li>
             </ul>
           </div>
           <div className="code">
@@ -108,6 +125,7 @@ class ModalPage extends Component {
           <p className="code">{"import { Modal as ModalWithOutFooter } from '@pearson-components/modal';"}</p>
           <p className="code">{'<ModalWithFooter isShown={firstModalIsShown} disableSuccessBtn={false} text={text} footerVisible={true} cancelBtnHandler={() => this.setState({firstModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithFooter>'}</p>
           <p className="code">{'<ModalWithOutFooter isShown={secondModalIsShown} text={text} footerVisible={false} cancelBtnHandler={() => this.setState({secondModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithOutFooter>'}</p>
+          <p className="code">{'<modalWithOutClose isShown={thirdModalIsShown} text={text} footerVisible={false} hideCloseButton={true} cancelBtnHandler={() => this.setState({thirdModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithoutClose>'}</p>
         </div>
       )
     }
@@ -124,6 +142,10 @@ function _firstButtonHandler (){
 
 function _secondButtonHandler (){
   this.setState({secondModalIsShown:true});
+}
+
+function _thirdButtonHandler (){
+  this.setState({thirdModalIsShown:true});
 }
 
 function _cancelBtnHandler (){

--- a/demo/translations/defaultMessages.js
+++ b/demo/translations/defaultMessages.js
@@ -14,6 +14,11 @@ export const messages = defineMessages({
     description    : 'text in initiating button',
     defaultMessage : 'Open Modal without Footer'
   },
+  initiatingButtonText3 : {
+    id             : 'initiatingButtonText3',
+    description    : 'text in initiating button',
+    defaultMessage : 'Open Modal without close button'
+  },
   modalSaveButtonText : {
     id             : 'modalSaveButtonText',
     description    : 'text in save button',

--- a/demo/translations/en-US.json
+++ b/demo/translations/en-US.json
@@ -1,6 +1,7 @@
 {
 "initiatingButtonText"  : "Open Modal with Footer",
 "initiatingButtonText2" : "Open Modal without Footer",
+"initiatingButtonText3" : "Open Modal without close button",
 "modalSaveButtonText"   : "Success Button",
 "modalCancelButtonText" : "Cancel Button",
 "headerTitle"           : "Basic Title",

--- a/demo/translations/fr.json
+++ b/demo/translations/fr.json
@@ -1,6 +1,7 @@
 {
   "initiatingButtonText"  : "French Open Modal with Footer",
   "initiatingButtonText2" : "French Open Modal without Footer",
+  "initiatingButtonText3" : "French Open Modal without close button",
   "modalSaveButtonText"   : "le Success button",
   "modalCancelButtonText" : "le Cancel button",
   "headerTitle"           : "French Basic Title",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "pearson-components"
   ],
   "dependencies": {
-    "pearson-compounds": "^0.4.3",
+    "pearson-compounds": "^0.8.1",
     "react-modal": "^1.7.7"
   }
 }

--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -8,6 +8,10 @@ import '../scss/Modal.scss';
 
 class Modal extends Component {
 
+  static defaultProps = {
+    shouldCloseOnOverlayClick: true
+  };
+
   constructor(props) {
     super(props);
 
@@ -32,22 +36,23 @@ class Modal extends Component {
 
   render() {
 
-    const { isShown, footerVisible, text, children, disableSuccessBtn } = this.props;
+    const { isShown, footerVisible, text, children, disableSuccessBtn, shouldCloseOnOverlayClick, hideCloseButton } = this.props;
 
     return (
         <BaseModal
-          className        = "pe-template__static-medium modalContent"
-          overlayClassName = "modalOverlay"
-          isOpen           = {isShown}
-          onAfterOpen      = {this.afterOpen}
-          onRequestClose   = {this.onClose}
-          ariaHideApp      = {false}
-          role             = "dialog"
-          contentLabel     = "Modal"
+          overlayClassName          = "pe-template__static-medium modalContent"
+          overlayClassName          = "modalOverlay"
+          isOpen                    = {isShown}
+          onAfterOpen               = {this.afterOpen}
+          onRequestClose            = {this.onClose}
+          ariaHideApp               = {false}
+          role                      = "dialog"
+          contentLabel              = "Modal"
+          shouldCloseOnOverlayClick = {shouldCloseOnOverlayClick}
   	      >
 
           <div id="modalHeader" className="modalHeader">
-            {!footerVisible && <button className="modalClose pe-icon--btn" onClick={this.cancelBtnHandler}>
+            {!footerVisible && !hideCloseButton && <button className="modalClose pe-icon--btn" onClick={this.cancelBtnHandler}>
               <Icon name='remove-sm-24'>{text.closeButtonSRText}</Icon>
             </button>}
             {text.headerTitle && <h2 id="modalHeaderText" className="modalHeaderText pe-title">{text.headerTitle}</h2>}
@@ -71,12 +76,13 @@ export default Modal;
 
 
 Modal.propTypes = {
-  successBtnHandler : PropTypes.func,
-  cancelBtnHandler  : PropTypes.func,
-  text              : PropTypes.object,
-  footerVisible     : PropTypes.bool
+  successBtnHandler         : PropTypes.func,
+  cancelBtnHandler          : PropTypes.func,
+  text                      : PropTypes.object,
+  footerVisible             : PropTypes.bool,
+  shouldCloseOnOverlayClick : PropTypes.bool,
+  hideCloseButton           : PropTypes.bool
 };
-
 
 export function _onClose() {
   this.cancelBtnHandler();
@@ -113,7 +119,11 @@ export function _afterOpen() {
   this.applyWrapper();
 
   // apply Focus to close button on open...
-  headerCloseButton ? headerCloseButton.focus() : footerCloseButton.focus();
+  if (headerCloseButton) {
+    headerCloseButton.focus();
+  } else {
+    footerCloseButton && footerCloseButton.focus();
+  }
 
   // apply padding based on clientHeight...
   const windowHeight  = window.innerHeight;

--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -40,7 +40,7 @@ class Modal extends Component {
 
     return (
         <BaseModal
-          overlayClassName          = "pe-template__static-medium modalContent"
+          className                 = "pe-template__static-medium modalContent"
           overlayClassName          = "modalOverlay"
           isOpen                    = {isShown}
           onAfterOpen               = {this.afterOpen}
@@ -53,7 +53,7 @@ class Modal extends Component {
 
           <div id="modalHeader" className="modalHeader">
             {!footerVisible && !hideCloseButton && <button className="modalClose pe-icon--btn" onClick={this.cancelBtnHandler}>
-              <Icon name='remove-sm-24'>{text.closeButtonSRText}</Icon>
+              <Icon name="remove-sm-24">{text.closeButtonSRText}</Icon>
             </button>}
             {text.headerTitle && <h2 id="modalHeaderText" className="modalHeaderText pe-title">{text.headerTitle}</h2>}
           </div>


### PR DESCRIPTION
Console has a use case where a 'modal' opens but should not be cancelable
- added `shouldCloseOnOverlayClick` prop which is just a passthrough to `react-modal`. defaults to true
- added `hideCloseButton` prop which will not show the close `x`. 

Noticing an error in console on demo page but it seems to be in master, not sure what's up