### PR TITLE
fix: use WillReceiveProps for improved cleanup

### DIFF
--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -26,13 +26,11 @@ class Modal extends Component {
 
   };
 
-  shouldComponentUpdate(nextState, nextProps){
+  componentWillReceiveProps(nextProps){
     if (nextProps && !nextProps.isShown && this.props.isShown){
       this.cancelBtnHandler();
     }
-    return true;
   }
-
 
   render() {
 


### PR DESCRIPTION
console was running into issues with our different modals conflicting with each other and not being cleaned up appropriately. If you were on a page with a modal and navigated to another page with a modal, often times the 2nd page modal would cause errors. I believe this should resolve those issues.