### PR TITLE
feat: allow passing ariaHideApp and appElement to set aria-role on sp…

### DIFF
--- a/demo/ModalPage.js
+++ b/demo/ModalPage.js
@@ -6,6 +6,7 @@ import { Button }           from 'pearson-compounds';
 import { Modal as ModalWithOutFooter } from '../index';
 import { Modal as ModalWithFooter }    from '../index';
 import { Modal as ModalWithoutClose }  from '../index';
+import { Modal as ModalWithAppWrapper }  from '../index';
 
 class ModalPage extends Component {
 
@@ -15,17 +16,20 @@ class ModalPage extends Component {
     this.state = {
       firstModalIsShown  : false,
       secondModalIsShown : false,
+      thirdModalIsShown  : false,
+      fourthModalIsShown : false
     };
 
     this.firstButtonHandler  = _firstButtonHandler.bind(this);
     this.secondButtonHandler = _secondButtonHandler.bind(this);
     this.thirdButtonHandler  = _thirdButtonHandler.bind(this);
+    this.fourthButtonHandler  = _fourthButtonHandler.bind(this);
 
   }
 
   render() {
 
-    const { firstModalIsShown, secondModalIsShown, thirdModalIsShown } = this.state;
+    const { firstModalIsShown, secondModalIsShown, thirdModalIsShown, fourthModalIsShown } = this.state;
 
     // ======================Internationalization Example=======================
     // intl prop is injected by the injectIntl() at the bottom of the page...
@@ -38,6 +42,7 @@ class ModalPage extends Component {
       initiatingButtonText  : intl.formatMessage(messages.initiatingButtonText),
       initiatingButtonText2 : intl.formatMessage(messages.initiatingButtonText2),
       initiatingButtonText3 : intl.formatMessage(messages.initiatingButtonText3),
+      initiatingButtonText4 : intl.formatMessage(messages.initiatingButtonText4),
       headerTitle           : intl.formatMessage(messages.headerTitle),
       bodyText              : intl.formatMessage(messages.bodyText),
       closeButtonSRText     : intl.formatMessage(messages.closeButtonSRText),
@@ -67,6 +72,10 @@ class ModalPage extends Component {
             <ModalWithoutClose id="modalWithOutClose" isShown={thirdModalIsShown} text={text} srHeaderText={text.srHeaderText} footerVisible={false} hideCloseButton={true} cancelBtnHandler={() => this.setState({thirdModalIsShown:false})} successBtnHandler={() => this.setState({thirdModalIsShown:false})} >
               <p>{text.bodyText}</p>
             </ModalWithoutClose>
+
+            <ModalWithAppWrapper id="ModalWithAppWrapper" isShown={fourthModalIsShown} text={text} srHeaderText={text.srHeaderText} footerVisible={true} cancelBtnHandler={() => this.setState({fourthModalIsShown: false})} successBtnHandler={() => this.setState({fourthModalIsShown:false})} ariaHideApp={true} appElement={document.getElementById('app')} >
+              <p>{text.bodyText}</p>
+            </ModalWithAppWrapper>
             <Button
               btnType="primary"
               btnSize="xlarge"
@@ -95,6 +104,17 @@ class ModalPage extends Component {
               onClick={this.thirdButtonHandler}
               >
               {text.initiatingButtonText3}
+            </Button>
+
+            <br />
+            <br />
+
+            <Button
+              btnType="cta"
+              btnSize="xlarge"
+              onClick={this.fourthButtonHandler}
+              >
+              {text.initiatingButtonText4}
             </Button>
           </div>
 
@@ -128,6 +148,7 @@ class ModalPage extends Component {
           <p className="code">{'<ModalWithFooter isShown={firstModalIsShown} disableSuccessBtn={false} text={text} srHeaderText={text.srHeaderText} footerVisible={true} cancelBtnHandler={() => this.setState({firstModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithFooter>'}</p>
           <p className="code">{'<ModalWithOutFooter isShown={secondModalIsShown} text={text} footerVisible={false} srHeaderText={text.srHeaderText} cancelBtnHandler={() => this.setState({secondModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithOutFooter>'}</p>
           <p className="code">{'<modalWithOutClose isShown={thirdModalIsShown} text={text} footerVisible={false} srHeaderText={text.srHeaderText} hideCloseButton={true} cancelBtnHandler={() => this.setState({thirdModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ><p>{text.bodyText}</p></ModalWithoutClose>'}</p>
+          <p className="code">{`<ModalWithAppWrapper isShown={thirdModalIsShown} text={text} footerVisible={false} srHeaderText={text.srHeaderText} hideCloseButton={true} cancelBtnHandler={() => this.setState({thirdModalIsShown:false})} successBtnHandler={() => console.log("Success!!!!!!")} ariaHideApp={true} appElement={document.getElementById('app')}><p>{text.bodyText}</p></ModalWithAppWrapper>`}</p>
         </div>
       )
     }
@@ -148,6 +169,10 @@ function _secondButtonHandler (){
 
 function _thirdButtonHandler (){
   this.setState({thirdModalIsShown:true});
+}
+
+function _fourthButtonHandler (){
+  this.setState({fourthModalIsShown:true});
 }
 
 function _cancelBtnHandler (){

--- a/demo/translations/defaultMessages.js
+++ b/demo/translations/defaultMessages.js
@@ -19,6 +19,11 @@ export const messages = defineMessages({
     description    : 'text in initiating button',
     defaultMessage : 'Open Modal without close button'
   },
+  initiatingButtonText4 : {
+    id             : 'initiatingButtonText4',
+    description    : 'text in initiating button',
+    defaultMessage : 'Open Modal that wrapps app instead of creating wrapper div'
+  },
   modalSaveButtonText : {
     id             : 'modalSaveButtonText',
     description    : 'text in save button',

--- a/demo/translations/en-US.json
+++ b/demo/translations/en-US.json
@@ -2,6 +2,7 @@
 "initiatingButtonText"  : "Open Modal with Footer",
 "initiatingButtonText2" : "Open Modal without Footer",
 "initiatingButtonText3" : "Open Modal without close button",
+"initiatingButtonText4" : "Open Modal that wrapps app instead of creating wrapper div",
 "modalSaveButtonText"   : "Success Button",
 "modalCancelButtonText" : "Cancel Button",
 "headerTitle"           : "Basic Title",

--- a/demo/translations/fr.json
+++ b/demo/translations/fr.json
@@ -2,6 +2,7 @@
   "initiatingButtonText"  : "French Open Modal with Footer",
   "initiatingButtonText2" : "French Open Modal without Footer",
   "initiatingButtonText3" : "French Open Modal without close button",
+  "initiatingButtonText4" : "French Open Modal that wrapps app instead of creating wrapper div",
   "modalSaveButtonText"   : "le Success button",
   "modalCancelButtonText" : "le Cancel button",
   "headerTitle"           : "French Basic Title",

--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -36,7 +36,6 @@ class Modal extends Component {
   render() {
 
     const { isShown, footerVisible, text, children, disableSuccessBtn, shouldCloseOnOverlayClick, hideCloseButton, srHeaderText } = this.props;
-
     return (
           <BaseModal
             className        = "pe-template__static-medium modalContent"
@@ -44,10 +43,11 @@ class Modal extends Component {
             isOpen           = {isShown}
             onAfterOpen      = {this.afterOpen}
             onRequestClose   = {this.onClose}
-            ariaHideApp      = {false}
             role             = "dialog"
             contentLabel     = "Modal"
             shouldCloseOnOverlayClick = {shouldCloseOnOverlayClick}
+            appElement       = {this.props.appElement}
+            ariaHideApp      = {this.props.ariaHideApp}
             aria             = {{
               labelledby  : "modalHeaderText",
               modal       : true
@@ -92,7 +92,8 @@ Modal.propTypes = {
   hideCloseButton           : PropTypes.bool,
   isShown                   : PropTypes.bool,
   disableSuccessBtn         : PropTypes.bool,
-
+  ariaHideApp               : PropTypes.bool,
+  appElement                : PropTypes.instanceOf(Element)
 };
 
 export function _onClose() {
@@ -130,8 +131,10 @@ export function _afterOpen() {
   const header            = document.getElementsByClassName('modalHeader')[0];
   const footer            = document.getElementsByClassName('modalFooter')[0];
 
-  // apply accessibility wrapper...
-  this.applyWrapper();
+  // apply accessibility wrapper if no appElement is given
+  if (!this.props.appElement) {
+    this.applyWrapper();
+  }
 
   // apply Focus to close button on open...
   modalContent.focus();

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -23,7 +23,7 @@
     left             : 0;
     height           : 100%;
     width            : 100%;
-    z-index          : 1001;
+    z-index          : 1400;
   }
 
   h2.modalHeaderText{

--- a/test/shell_scripts/run_tests.sh
+++ b/test/shell_scripts/run_tests.sh
@@ -5,7 +5,7 @@ echo "Trigger the Selenium tests for rebrand branch: ux-test-platform repo...."
 #Step 1: API to trigger the ux-test-platform build with the below config
 body="{
 \"request\": {
-\"message\": \"feat(modal): Run Modal Tests\",
+\"message\": \"feat(modal): Run tests for $TRAVIS_BRANCH\",
 \"branch\":\"rebrand\",
 \"config\": {
 \"script\": [
@@ -34,7 +34,7 @@ REPO_URI="https://api.travis-ci.org/repos/Pearson-Higher-Ed/ux-test-platform/bui
 i=1
 max=20
 while [ $i -lt $max ]
-do  
+do
   curl -i $REPO_URI > test.json #Push the json response to a temp file 'test.json'
 
   LATEST_STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of the last build
@@ -50,8 +50,8 @@ do
   then LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #
   echo "LATEST_ID of rebrand branch.............................. $LATEST_ID"
   export LATEST_ID
-    break 
-  else  
+    break
+  else
     true $(( i++ ))
     sleep 1
   fi
@@ -69,7 +69,7 @@ max=900 #Max time for the tests to run.
 while [ $i -lt $max ]
 do
 
-curl -i $REPO_URI_WITH_BUILDID > test.json 
+curl -i $REPO_URI_WITH_BUILDID > test.json
 
 STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of rebrand build
 #RESULT=$(grep -o '"result":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #For debug


### PR DESCRIPTION
…ecific element

`applyWrapper` was causing some unusual behavior once and awhile because it throws everything inside of another div. The main "big" issue we were seeing is that sometimes our icons would disappear when opening the modal in IE. We've run into other strange stuff in the past but I can't remember what now 😄 

This feature lets us pass the `ariaHideApp` and `appElement` props used by react-modal to use its method of `aria-hidden` changes.

@StommePoes mentioned that the wrapper was originally added to save adding the `aria-hidden` attribute to the element containing the modal itself, but I am not seeing this happen. I used chrome's a11y tools to inspect the accessibility tree and only see the modal in the tree when it is open. 

Anyways, treat this is a tentative change as I don't want to undo anything that `wrapper` was doing to fix shortcomings in react-modal's accessibility. 