### PR TITLE
Change sr text for close button from child of Icon to aria-label attr

### DIFF
--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -184,10 +184,9 @@ export default class Modal extends Component {
 
               <div id="modalHeader" className={`modalHeader ${headerClass}`}>
                 {!footerVisible && !hideCloseButton &&
-                  <button className="modalClose pe-icon--btn" onClick={this.cancelBtnHandler}>
-                    <Icon name="remove-sm-24">
-                      {text.closeButtonSRText}
-                    </Icon>
+                  <button className="modalClose pe-icon--btn" onClick={this.cancelBtnHandler}
+                          aria-label={text.closeButtonSRText}>
+                    <Icon name="remove-sm-24" />
                   </button>}
                 {text.headerTitle  &&
                   <h2 id="modalHeaderText" className="modalHeaderText pe-title">


### PR DESCRIPTION
When passing the SR text in as a child of Icon, a title tag is rendered inside of, and used to label, the svg tag. This causes NVDA to read the SR text twice.