### PR TITLE
Modal footer focus order

### DIFF
--- a/src/js/Modal.js
+++ b/src/js/Modal.js
@@ -146,10 +146,11 @@ export default class Modal extends Component {
     if (footerVisible) {
       return (
         <div className="modalFooter">
-          <button onClick={this.cancelBtnHandler}
-                  className="modalCancel pe-btn--btn_large">{text.modalCancelButtonText}</button>
           <button onClick={this.successBtnHandler} className='modalSave pe-btn__primary--btn_large' id={saveBtnId}
                   disabled={disableSuccessBtn}>{text.modalSaveButtonText}</button>
+          <button onClick={this.cancelBtnHandler}
+                  className="modalCancel pe-btn--btn_large">{text.modalCancelButtonText}</button>
+          
         </div>
       )
     }

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -76,10 +76,14 @@
           .modalFooter {
             padding : 0px 40px 40px 40px;
             text-align: right;
+            display:flex;
+            flex-direction:row;
+            justify-content:flex-end;
           }
 
           .modalSave {
             margin-left: 14px;
+            order: 2;
           }
 
           .modalClose{
@@ -90,6 +94,7 @@
             text-decoration  : none;
             border           : none;
             background-color : inherit;
+            order:1;
           }
 
         };
@@ -135,10 +140,14 @@
           .modalFooter {
             padding : 0px 40px 40px 40px;
             text-align: right;
+            display:flex;
+            flex-direction:row;
+            justify-content:flex-end;
           }
 
           .modalSave {
             margin-left: 14px;
+            order:2;
           }
 
           .modalClose{
@@ -149,6 +158,7 @@
             text-decoration  : none;
             border           : none;
             background-color : inherit;
+            order:1;
           }
 
         };
@@ -200,11 +210,13 @@
           .modalSave{
             flex   : 1 0 auto;
             margin : 6px 4px 6px 4px;
+            order:2;
           }
 
           .modalCancel{
             flex   : 1 0 auto;
             margin : 6px 4px 6px 4px;
+            order:1;
           }
 
           .modalClose{
@@ -270,11 +282,13 @@
           .modalSave{
             flex   : 1 0 50%;
             margin : 6px 4px 6px 4px;
+            order:2;
           }
 
           .modalCancel{
             flex   : 1 0 50%;
             margin : 6px 4px 6px 4px;
+            order:1;
           }
 
           .modalClose{


### PR DESCRIPTION
Switched button order in DOM so focus goes to success button first.
Retained visual order by adding css order property (added display:flex to footer as well).